### PR TITLE
fix e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	[ ! -d config/crd ] || { $(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -; }
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.63.4
+KUEUE_VERSION ?= v0.10.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -223,3 +224,8 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
+
+.PHONY: kueue
+kueue:
+	kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/$(KUEUE_VERSION)/manifests.yaml
+	kubectl rollout status deployment/kueue-controller-manager -n kueue-system --timeout 300s

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -227,8 +227,8 @@ func main() {
 		watcher.NewConfigAdmitter(
 			mgr.GetClient(),
 			types.NamespacedName{
-				Namespace: "kueue-external-admission",
-				Name:      "config",
+				Namespace: "alert-manager-kueue-admission-system",
+				Name:      "alert-mgr-kueue-admission-config",
 			},
 			ctrl.Log.WithName("config-admitter"),
 		),

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: alert-manager-kueue-admission-system
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: alert-manager-kueue-admission-
+namePrefix: alert-mgr-kueue-admission-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: system
+data:
+  shouldAdmit: "false"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,9 @@
 resources:
 - manager.yaml
+- configmap.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: example.com/alert-manager-kueue-admission
+  newTag: v0.0.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - kueue.x-k8s.io.konflux-ci.dev
+  - kueue.x-k8s.io
   resources:
   - admissionchecks
   - workloads
@@ -18,14 +18,14 @@ rules:
   - update
   - watch
 - apiGroups:
-  - kueue.x-k8s.io.konflux-ci.dev
+  - kueue.x-k8s.io
   resources:
   - admissionchecks/finalizers
   - workloads/finalizers
   verbs:
   - update
 - apiGroups:
-  - kueue.x-k8s.io.konflux-ci.dev
+  - kueue.x-k8s.io
   resources:
   - admissionchecks/status
   - workloads/status

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kueue.x-k8s.io
   resources:
   - admissionchecks

--- a/configmap.yaml
+++ b/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config
+  name: alert-mgr-kueue-admission-config
   namespace: kueue-external-admission
 data:
   shouldAdmit: "false"

--- a/internal/controller/admissioncheck_controller.go
+++ b/internal/controller/admissioncheck_controller.go
@@ -41,9 +41,9 @@ type AdmissionCheckReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=admissionchecks,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=admissionchecks/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=admissionchecks/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -32,8 +32,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-const IndexByHasAdmission = "status.hasAdmission"
-const HasAdmission = "hasAdmission"
+const (
+	IndexByHasAdmission = "status.hasAdmission"
+	HasAdmission        = "hasAdmission"
+)
 
 // WorkloadReconciler reconciles a Workload object
 type WorkloadReconciler struct {
@@ -50,9 +52,9 @@ func NewWorkloadController(client client.Client, schema *runtime.Scheme, admitte
 	}
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=workloads,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=workloads/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io.konflux-ci.dev,resources=workloads/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -175,6 +177,5 @@ func SetupIndex(ctx context.Context, indexer client.FieldIndexer) error {
 		}
 
 		return []string{HasAdmission}
-
 	})
 }

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -2,9 +2,8 @@ package watcher
 
 import (
 	"context"
-	"time"
-
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
+
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 type Lister interface {
 	List() ([]client.Object, error)
@@ -37,7 +38,6 @@ func NewWatcher(
 	admitter Admitter,
 	period time.Duration,
 ) (*Watcher, <-chan event.GenericEvent) {
-
 	ch := make(chan event.GenericEvent)
 
 	return &Watcher{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,7 +37,7 @@ const namespace = "alert-manager-kueue-admission-system"
 const serviceAccountName = "alert-manager-kueue-admission-controller-manager"
 
 // metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "alert-manager-kueue-admission-controller-manager-metrics-service"
+const metricsServiceName = "alert-mgr-kueue-admission-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
 const metricsRoleBindingName = "alert-manager-kueue-admission-metrics-binding"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,13 +34,13 @@ import (
 const namespace = "alert-manager-kueue-admission-system"
 
 // serviceAccountName created for the project
-const serviceAccountName = "alert-manager-kueue-admission-controller-manager"
+const serviceAccountName = "alert-mgr-kueue-admission-controller-manager"
 
 // metricsServiceName is the name of the metrics service of the project
 const metricsServiceName = "alert-mgr-kueue-admission-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "alert-manager-kueue-admission-metrics-binding"
+const metricsRoleBindingName = "alert-mgr-kueue-admission-metrics-binding"
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
@@ -178,7 +178,7 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should ensure the metrics endpoint is serving metrics", func() {
 			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
 			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=alert-manager-kueue-admission-metrics-reader",
+				"--clusterrole=alert-mgr-kueue-admission-metrics-reader",
 				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 			)
 			_, err := utils.Run(cmd)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,9 +49,14 @@ var _ = Describe("Manager", Ordered, func() {
 	// enforce the restricted security policy to the namespace, installing CRDs,
 	// and deploying the controller.
 	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
+		By("deploying kueue")
+		cmd := exec.Command("make", "kueue", fmt.Sprintf("IMG=%s", projectImage))
 		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install kueue")
+
+		By("creating manager namespace")
+		cmd = exec.Command("kubectl", "create", "ns", namespace)
+		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
 
 		By("labeling the namespace to enforce the restricted security policy")


### PR DESCRIPTION
- **fix CRD install error in e2e tests**: we don't have CRDs, this change checks if the folder exists before applying
- **fix name too long**: once the prefix is added, the name for the metrics service gets too long
- **install kueue as part of e2e test setup**: we need kueue to be installed (or at least its CRD) to run the controller
- **fix rbac**: we are missing permission to load the configmap
- **fix configmap**: configmap was not created
