### PR TITLE
Change the deployment namespace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -231,7 +231,7 @@ func main() {
 		watcher.NewConfigAdmitter(
 			mgr.GetClient(),
 			types.NamespacedName{
-				Namespace: "alert-manager-kueue-admission-system",
+				Namespace: "kueue-external-admission",
 				Name:      "alert-mgr-kueue-admission-config",
 			},
 			ctrl.Log.WithName("config-admitter"),

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: alert-manager-kueue-admission-system
+namespace: kueue-external-admission
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 // namespace where the project is deployed in
-const namespace = "alert-manager-kueue-admission-system"
+const namespace = "kueue-external-admission"
 
 // serviceAccountName created for the project
 const serviceAccountName = "alert-mgr-kueue-admission-controller-manager"


### PR DESCRIPTION
The current namespace is alert-manager-kueue-admission-system. Some managed clusters doesn't allow namespace with the suffix "system".